### PR TITLE
Fix #4: IE11 compatibility

### DIFF
--- a/src/Web/Internal/FFI.js
+++ b/src/Web/Internal/FFI.js
@@ -2,12 +2,14 @@
 
 exports._unsafeReadProtoTagged = function (nothing, just, name, value) {
   var obj = value;
+  var longname = "[object " + name + "]";
   while (obj != null) {
     var proto = Object.getPrototypeOf(obj);
     var ctor = proto.constructor.name;
-    if (ctor === name) {
+    var longctor = proto.constructor.toString();
+    if (ctor === name || longctor === longname) {
       return just(value);
-    } else if (ctor === "Object") {
+    } else if (ctor === "Object" || longctor === "[object Object]") {
       return nothing;
     }
     obj = proto;


### PR DESCRIPTION
`constructor.name` does not seem to work on IE11, so we also check `constructor.toString()`.