### PR TITLE
Fix _unsafeReadProtoTagged in node.js

### DIFF
--- a/src/Web/Internal/FFI.js
+++ b/src/Web/Internal/FFI.js
@@ -1,9 +1,23 @@
 "use strict";
 
 exports._unsafeReadProtoTagged = function (nothing, just, name, value) {
-  var ty = window[name];
-  if (ty != null && value instanceof ty) {
-    return just(value);
+  if (typeof window !== 'undefined') {
+    var ty = window[name];
+    if (ty != null && value instanceof ty) {
+      return just(value);
+    }
+  } else {
+    var obj = value;
+    while (obj != null) {
+      var proto = Object.getPrototypeOf(obj);
+      var constructorName = proto.constructor.name;
+      if (constructorName === name) {
+        return just(value);
+      } else if (constructorName === "Object") {
+        return nothing;
+      }
+      obj = proto;
+    }
   }
   return nothing;
 };

--- a/src/Web/Internal/FFI.js
+++ b/src/Web/Internal/FFI.js
@@ -1,23 +1,23 @@
 "use strict";
 
 exports._unsafeReadProtoTagged = function (nothing, just, name, value) {
-  if (typeof window !== 'undefined') {
+  if (typeof window !== "undefined") {
     var ty = window[name];
     if (ty != null && value instanceof ty) {
       return just(value);
     }
-  } else {
-    var obj = value;
-    while (obj != null) {
-      var proto = Object.getPrototypeOf(obj);
-      var constructorName = proto.constructor.name;
-      if (constructorName === name) {
-        return just(value);
-      } else if (constructorName === "Object") {
-        return nothing;
-      }
-      obj = proto;
+    return nothing;
+  } 
+  var obj = value;
+  while (obj != null) {
+    var proto = Object.getPrototypeOf(obj);
+    var constructorName = proto.constructor.name;
+    if (constructorName === name) {
+      return just(value);
+    } else if (constructorName === "Object") {
+      return nothing;
     }
+    obj = proto;
   }
   return nothing;
 };


### PR DESCRIPTION
It is possible to use purescript-web-events on the server side using node.js and the 'ws' package and purescript-web-socket. However the current imlementation of purescript-web-events depends on `window`, which obviously doesn't work on the server side.

Even though node.js has `global`, that doesn't necessarily give us access to the class/constructor defining any particular Event anyway (e.g. MessageEvent from ws / purescript-web-socket). 

In this pull request we preserve the instanceof check if `window` is defined, and fall back to an older implementation if `window` is not defined. This way this library doesn't break node.