### PR TITLE
Do not rely on window in _unsafeReadProtoTagged

### DIFF
--- a/src/Web/Internal/FFI.js
+++ b/src/Web/Internal/FFI.js
@@ -1,6 +1,12 @@
 "use strict";
 
 exports._unsafeReadProtoTagged = function (nothing, just, name, value) {
+  if (typeof window !== "undefined") {
+    var ty = window[name];
+    if (ty != null && value instanceof ty) {
+      return just(value);
+    }
+  }
   var obj = value;
   while (obj != null) {
     var proto = Object.getPrototypeOf(obj);

--- a/src/Web/Internal/FFI.js
+++ b/src/Web/Internal/FFI.js
@@ -1,13 +1,6 @@
 "use strict";
 
 exports._unsafeReadProtoTagged = function (nothing, just, name, value) {
-  if (typeof window !== "undefined") {
-    var ty = window[name];
-    if (ty != null && value instanceof ty) {
-      return just(value);
-    }
-    return nothing;
-  } 
   var obj = value;
   while (obj != null) {
     var proto = Object.getPrototypeOf(obj);


### PR DESCRIPTION
Close #10 

A reproducible (on Chrome) example is here https://codepen.io/rnons/pen/gObLQzY?editors=1011

```html
<!-- index.html -->
<iframe></iframe>
<script>
const iframe = document.querySelector('iframe')
  iframe.contentWindow.addEventListener('click', ev => {
    console.log(ev.constructor.name)
    console.log(ev instanceof window.MouseEvent) // false!
  })
</script>
```