### PR TITLE
Add addEventListener variant with options exposed

### DIFF
--- a/src/Web/Event/EventTarget.js
+++ b/src/Web/Event/EventTarget.js
@@ -6,6 +6,18 @@ export function eventListener(fn) {
   };
 }
 
+export function addEventListenerOpt(type) {
+  return function (listener) {
+    return function (options) {
+      return function (target) {
+        return function () {
+          return target.addEventListener(type, listener, options);
+        };
+      };
+    };
+  };
+}
+
 export function addEventListener(type) {
   return function (listener) {
     return function (useCapture) {

--- a/src/Web/Event/EventTarget.purs
+++ b/src/Web/Event/EventTarget.purs
@@ -29,6 +29,32 @@ foreign import eventListener
    . (Event -> Effect a)
   -> Effect EventListener
 
+foreign import addEventListenerOpt
+  :: EventType
+  -> EventListener
+  -> { capture :: Boolean
+     , once :: Boolean
+     , passive :: Boolean
+     }
+  -> EventTarget
+  -> Effect Unit
+
+-- | Adds a listener to an event target.
+-- | - `capture` - whether the listener is added to the "capture" phase
+-- | - `once` - if true, indicates listener should be invokved at most once
+-- |            before being automatically removed.
+-- | - `passive` - indicates the callback function will never call `preventDefault`
+addEventListener'
+  :: EventType
+  -> EventListener
+  -> { capture :: Boolean
+     , once :: Boolean
+     , passive :: Boolean
+     }
+  -> EventTarget
+  -> Effect Unit
+addEventListener' = addEventListenerOpt
+
 -- | Adds a listener to an event target. The boolean argument indicates whether
 -- | the listener should be added for the "capture" phase.
 foreign import addEventListener


### PR DESCRIPTION
**Description of the change**

Fixes #8. I haven't added support for the `signal` option because that means this lib needs to depend on `web-fetch`, and I'm not sure how that affects the dependencies.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
