### PR TITLE
Add support for `relatedTarget`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Add support for `relatedTarget` field to `Event` (#32 by @ad-si)
 
 Bugfixes:
 

--- a/src/Web/Event/Event.js
+++ b/src/Web/Event/Event.js
@@ -10,6 +10,10 @@ export function _currentTarget(e) {
   return e.currentTarget;
 }
 
+export function _relatedTarget(e) {
+  return e.relatedTarget;
+}
+
 export function defaultPrevented(e) {
   return function() {
     return e.defaultPrevented;

--- a/src/Web/Event/Event.purs
+++ b/src/Web/Event/Event.purs
@@ -4,6 +4,7 @@ module Web.Event.Event
   , type_
   , target
   , currentTarget
+  , relatedTarget
   , eventPhase
   , stopPropagation
   , stopImmediatePropagation
@@ -47,6 +48,12 @@ currentTarget :: Event -> Maybe EventTarget
 currentTarget = toMaybe <<< _currentTarget
 
 foreign import _currentTarget :: Event -> Nullable EventTarget
+
+-- | The secondary target for the event.
+relatedTarget :: Event -> Maybe EventTarget
+relatedTarget = toMaybe <<< _relatedTarget
+
+foreign import _relatedTarget :: Event -> Nullable EventTarget
 
 -- | Indicates which phase of the event flow that is currently being processed
 -- | for the event.


### PR DESCRIPTION
`relatedTarget` is quite helpful for `MouseEvent`s, `FocusEvent`s, etc. where you are moving from one element to another one.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
